### PR TITLE
Revised handle click outside event to use closeDatepickerOnClickOutside prop

### DIFF
--- a/src/DatePicker/HotelDatePicker.vue
+++ b/src/DatePicker/HotelDatePicker.vue
@@ -1092,11 +1092,12 @@ export default {
     },
     handleClickOutside(event) {
       const ignoreClickOnMeElement = this.$refs[`DatePicker-${this.hash}`]
+      const shouldCloseOnClickOutside = this.closeDatepickerOnClickOutside
 
       if (ignoreClickOnMeElement) {
         const isClickInsideElement = ignoreClickOnMeElement.contains(event.target)
 
-        if (!isClickInsideElement) {
+        if (!isClickInsideElement && shouldCloseOnClickOutside) {
           this.hideDatepicker()
         }
       }


### PR DESCRIPTION
This adds ability to use the existing `closeDatepickerOnClickOutside` prop that was originally provided to override close events, especially if the component is rendered in a Shadow DOM mode